### PR TITLE
add the shortcut module

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,7 @@
 Changes
+lib/say.pm
 lib/Say/Compat.pm
 Makefile.PL
 MANIFEST			This list of files
 t/basic.t
+t/use_say.t

--- a/lib/say.pm
+++ b/lib/say.pm
@@ -1,0 +1,31 @@
+package say;
+use strict;
+use warnings;
+use Say::Compat;
+
+BEGIN {
+    push our @ISA, 'Say::Compat';
+    our $VERSION = $Say::Compat::VERSION;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+say - Say::Compat shortcut
+
+=head1 SYNOPSIS
+
+    use say;
+
+    say "very easy to say!";
+
+=head1 DESCRIPTION
+
+We only have to know B<use say;>.
+
+=head1 SEE ALSO
+
+L<Say::Compat>

--- a/t/use_say.t
+++ b/t/use_say.t
@@ -1,0 +1,9 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use say;
+
+say "1..1";
+say STDOUT "ok 1";


### PR DESCRIPTION
I feel that it is a difficult way to find Say::Compat or remember Say::Compat when I want it.
So I deicided to add a shortcut in it. We only have to know 'say'.

```
use say;

say "something";
```
